### PR TITLE
[LIP-2] Lens Share

### DIFF
--- a/lens-share/README.md
+++ b/lens-share/README.md
@@ -1,0 +1,3 @@
+# Lens Share specification
+
+This folder contains the support material for [LIP-2] - Lens Share

--- a/lens-share/app-manifest-schema.json
+++ b/lens-share/app-manifest-schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "shortname": {
+      "type": "string",
+      "maxLength": 10
+    },
+    "name": {
+      "type": "string",
+      "maxLength": 36
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 140
+    },
+    "icon": {
+      "type": "string",
+      "format": "uri"
+    },
+    "image": {
+      "type": "string",
+      "format": "uri"
+    },
+    "platforms": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["mobile", "web", "desktop"]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "mappings": {
+      "type": "object",
+      "properties": {
+        "mobile": {
+          "$ref": "#/definitions/mappingProperties"
+        },
+        "web": {
+          "$ref": "#/definitions/mappingProperties"
+        },
+        "desktop": {
+          "$ref": "#/definitions/mappingProperties"
+        }
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "maxLength": 10
+      }
+    }
+  },
+  "required": [
+    "shortname",
+    "name",
+    "description",
+    "icon",
+    "image",
+    "platforms",
+    "mappings",
+    "tags"
+  ],
+  "definitions": {
+    "mappingProperties": {
+      "type": "object",
+      "properties": {
+        "home": {
+          "type": "string"
+        },
+        "profile": {
+          "type": "string"
+        },
+        "publication": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
title: Lens Share
description: A standard to share Lens profile and publications across the Lens ecosystem
author: Paweł Lula (@desfero), Cesare Naldi (@cesarenaldi), Kris Urbas (@krzysu)
status: Draft
type: Lens Ecosystem Standard
created: 2023-06-07

## Abstract

The increasing number of Lens ecosystem apps necessitates the ability to share URLs to publications and profiles in an app-agnostic manner, allowing users to utilize their preferred apps. However, there are instances where the user's preferred app may not be available on the current platform, creating a need to enhance the user experience by providing the option to choose from the available apps. This proposal examines the implementation of a standardized link sharing strategy and an app-agnostic interface, facilitating seamless integration among apps in the Lens ecosystem while preserving attribution to the original app.

## Motivation

Currently in order to share a URL on needs to copy & paste a very Lens app specific URL format. This is not necessarily portable as different apps lives on their own domains and implement different routing strategies.

Some Lens application are just mobile-only or web-only. So opening a URL on one of these platform could lead the user to a dead-end.

In the case the user opens a link leading to a new Lens app, the initial login overhead plus the the cognitive load required to understand the new UI, easily leads to losing focus on the original objective (opening the link). This is a suboptimal UX for the entire Lens ecosystem.

By introducing a common standard to share Lens links, this proposal aims at:

- simplify the share links process by defining a portable URL format
- provide attribution to the original app used to generate the link
- provide reliable embed metadata for social media link previews

## Specification

In order to function there are 3 elements:

- a Lens App registry
- a portable Lens Share link format
- a Lens Share UI responsible to handle the link and give options to the user

### Lens Share Registry

Define a Lens ecosystem apps registry that allows builder to register their app details such as name, icon, supported platforms, app specific URL formats, etc.

In order to do that this proposal defines the JSON schema of an Lens App Manifest that must be used to register a new app.

An example:

```json
{
  "shortname": "foobar",
  "name": "Foo Bar",
  "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ",
  "icon": "https://example.com/icon.png",
  "image": "https://example.com/image.png",
  "platforms": ["mobile", "web"],
  "mappings": {
    "mobile": {
      "home": "com.foobar://home",
      "profile": "com.foobar://user/:handle",
      "publication": "com.foobar://publication/:id"
    },
    "web": {
      "home": "http://example.com/",
      "profile": "http://example.com/u/:handle",
      "publication": "http://example.com/p/:id"
    }
  },
  "tags": ["foo", "bar", "social"]
}
```

The `:handle` and `:id` tokens represent placeholder for where the app expect Profile handles and Publication Ids. The specification could be extended to support Profile Ids if need to.

The app manifest should be submitted as PRs to the registry repository and a there should be a process in place to validate and approve new apps.

### Lens Share Link

Lens apps should adopt a common link format such as:

- `https://share.lens.xyz/u/<handle>` for Profiles
- `https://share.lens.xyz/p/<publication-id>` for Publications

The URL could also include an attribution parameter that allows to give visibility of the originating app.

Some examples:

```
https://share.lens.xyz/u/stani.lens?by=lenster

https://share.lens.xyz/p/0x01-0x01?by=orb
```

### Lens Share UI

The Lens Share UI is the one responding to `https://share.lens.xyz` requests. It should render a simple Lens branded interface that for the given URL and the current user's platform, shows a list of apps to pick from.

Once the app is chosen it will automatically redirect to the given app with the app specific URL details required to open the linked resource (Profile or Publication).

The sequence of events is:

- 1. User opens https://share.lens.xyz/u/stani.lens
- 2. Lens Share UI queries the Lens API for, in this example, profile with `stani.lens` handle
- 3. Lens Share UI renders a list of app available to open the link
  - The list shown should account for the capability of the platform of the requesting UA (e.g. offer mobile app options to mobile browsers only)
- 4. Use selects one of the option and the UI leads to the resolved app URL

If the link includes attribution details (e.g. `?by=phaver` param) such information will be used to clearly communicate the original app sued to generate the link. This with clear app messaging as well as boosting priority to the app in the list.

The user could express a preference to open any future links using the same app or "just once". Opening a new links will result in a immediate redirect to the chosen app. Such preference will be stored in the device using a simple cookie so that the redirect can happen with an efficient HTTP 302.

The sequence of events in this case is:

- 1. User opens https://share.lens.xyz/u/stani.lens
- 2. Server redirects with a 302 pointing at the resolved app URL

Opening the Lens Share UI at `https://share.lens.xyz` should provide an option to reset the user's preference.

The Lens Share UI will also implement industry standards such as OEmbed and OG tags so that shared links on social media could render rich URL previews. If the `by` attribution parameter is present the metadata could include incorporate elements of the app manifest to make the originating app brand surface in the preview. This could evolve over time into theming settings.

## Rationale

When evaluating if the Lens Share UI should be exposed over HTTP we entertained the idea of using a custom scheme such as `lens://`. This is a very interesting idea in the context of a web3 protocol but requires time for submitting the corresponding scheme specification to the IANA and it does require adoption from user agents. in the meantime an HTTP fallback strategy is anyway needed, so while this proposal does not exclude a future `lens://` it focuses on what is achievable today in times compatible with web3.

## Security Considerations

### Malicious apps

A reasonable security concern is around the process that allows apps to be added to the Lens Share Registry.
Currently a similar validation process is in place for accepting apps to be listed under https://www.lens.xyz/apps.

We should have a strict process here as well so that only apps from legit builders are included.

### URL sanitization

Strict validation and sanitization rules should be applied to incoming requests to avoid malicious URLs from impacting the user experience.

## Copyright

Copyright and related rights waived via CC0.
