### PR TITLE
[LIP-9] Lens-Wide Verification Process

### DIFF
--- a/LIPs/LIP-9.md
+++ b/LIPs/LIP-9.md
@@ -1,0 +1,19 @@
+LIP-9 Lens-Wide Verification Process
+----
+
+In light of LIP-5, which could/will open up the garden, a process for verified profiles becomes more relevant.
+
+Currently, each Interface/App build on top of the protocol has their own way to verfiy profiles.
+That makes it hard for new people to distinguish verified from non-verfied profiles, depending on the platform they got onboarded with
+(example: a verified profile on hey doesn't appear as verified on tape)
+
+Also, the newly introduced "reputation score" opens up new possibilities on that front.
+
+
+Here's an approach to start the discussion:
+
+- The protocol sets up a "database" that holds a list of all verified profiles.
+- Each platform can submit to that database, adding new profiles as verifed - in that case, the badge would show "Verified by XYZ" on all platforms that aggregate the list.
+- Each platform can choose to aggregate that list, but of course doesn't have to (tho it's recommended).
+- If you have a reputation score above a defined threshold, you can apply for a general/lenswide verfication
+- A "light verification" can be done individually by going through another process (like linking a github profie, etc...).


### PR DESCRIPTION
LIP-9 for setting up a lens-wide verification process
----

In light of LIP-5, which could/will open up the garden, a process for verified profiles becomes more relevant.

Currently, each Interface/App build on top of the protocol has their own way to verfiy profiles.
That makes it hard for new people to distinguish verified from non-verfied profiles, depending on the platform they got onboarded with.
(example: a verified profile on hey doesn't appear as verified on tape)
And for projects/brands it's a hassle to get verifid separately for each app/platform/interface.

Also, the newly introduced "reputation score" opens up new possibilities on that front.


Here's an approach to start the discussion:

- The protocol sets up a "database" that holds a list of all verified profiles.
- Each platform can submit to that database, adding new profiles as verifed - in that case, the badge would show "Verified by XYZ" on all platforms that aggregate the list.
- New platforms can apply to also be able to submit to that database
- Each platform can choose to aggregate that list, but of course doesn't have to (tho it's recommended).
- If you have a reputation score above a defined threshold, you can apply for a general/lenswide verfication
- A "light verification" can be done individually by going through another process (like linking a github profie, etc...).


Optional:
A "negative" entry. For example if a profile got stolen, impersonated, squatted, scams, etc...
So that this information can be accessed by all platforms across the protocol.
Tho this bears some risks, which probably should require a separate discussion (imho). 