### PR TITLE
LIP-20 - Deploy to GnosisChain

### DIFF
--- a/LIPs/lip-20.md
+++ b/LIPs/lip-20.md
@@ -1,0 +1,31 @@
+  ---
+title: Deploy Lens on GnosisChain
+description: Lip-20 opens the discussion of bringing Lens Protocol to GnosisChain
+author: seliqui (@seliqui)
+status: Draft
+type: Protocol
+created: (2024-03-16)
+
+
+## Abstract
+
+Lens Protocol is currenty on Polygon, but (afaik) there's a communication layer available that would make deployment on different chains possible, whilst still providing an unified experience for the users. The GnosisChain seems to be a good choice for being the first chain to expand to compared to L2s, especially because of their usage of a stable token for paying the Gas Fees it easier for long term gas calculations.
+
+## Motivation
+
+Since the Lens Protocol is chain agnostic, spreading to other chains is just a question of time.
+The GnosisChain - like Lens Protocol - is still undervaluated, but the xDai/Gnosis team proved the can get valuable things out. Like Gnosis Safe (now SAFE) or CowSwap. Also on GnosisChain, the EZB verified EURe by Monerium is available, opening the connection between the traditional banking system (IBAN) and the cryptospace. In addition, with GnosisPay in place (which leverages both Monerium EURe as well as Gnosis Safe) it offers the Option to have a VIA Card for payment with Crytpoassets in real life. Also GnosisChain is not just an additional L2, but a separate Sidechain, secured by it's own Beacon-Chain like Ethereum.
+
+
+
+## Specification and Rationale
+
+If adopted, Lens Protocol should be deployed on GnosisChain and the Protocol should provide an easy integration option for Lens Platforms/Applications to adapt to it. Ideally Platforms also support EURe along the way, combined with setting the GnosisPay as the receiving address. That would open up a unique usecase for creators:
+Make a post and collections / open actions rewards are instantly spendable IRL with their GnosisPay Card.
+
+(In case of covering Gas Fees, spearate neotioations with the Gnosis DAO might have to take place.)
+
+
+## Copyright
+
+Copyright and related rights waived via CC0.


### PR DESCRIPTION
  ---
title: Deploy Lens on GnosisChain
description: Lip-20 opens the discussion of bringing Lens Protocol to GnosisChain
author: seliqui (@seliqui)
status: Draft
type: Protocol
created: (2024-03-16)


## Abstract

Lens Protocol is currenty on Polygon, but (afaik) there's a communication layer available that would make deployment on different chains possible, whilst still providing an unified experience for the users. The GnosisChain seems to be a good choice for being the first chain to expand to compared to L2s, especially because of their usage of a stable token for paying the Gas Feesw which makes it easier for long term gas calculations. Also GnosisChain as good on-ramp options and with lens being permissionless (= users need to pay for a handle), Gnosis Users already have a stable token on hand. 8 xDai is better than 8 Matic (which could swing in price). Especially if we want to attract people outside the cryptospace who are not interested in speculations, but are creators looking for a new platform.

## Motivation

Since the Lens Protocol is chain agnostic, spreading to other chains is just a question of time.
The GnosisChain - like Lens Protocol - is still undervaluated, but the xDai/Gnosis team proved they can get valuable things out. Like Gnosis Safe (now SAFE) or CowSwap. Also on GnosisChain, the EZB verified EURe by Monerium is available, opening the connection between the traditional banking system (IBAN) and the cryptospace. In addition, with GnosisPay in place (which leverages both Monerium EURe as well as Gnosis Safe) it offers the Option to have a VISA Card for payment with Crytpoassets in real life. Also GnosisChain is not just an additional L2, but a separate Sidechain, secured by it's own Beacon-Chain like Ethereum.




## Specification and Rationale

If adopted, Lens Protocol should be deployed on GnosisChain and the Protocol should provide an easy integration option for Lens Platforms/Applications to adapt to it. Ideally Platforms also support EURe along the way, combined with setting the GnosisPay as the receiving address. That would open up a unique usecase for creators:
Make a post and collections / open actions rewards are instantly spendable IRL with their GnosisPay Card.

(In case of covering Gas Fees, spearate neotioations with the Gnosis DAO might have to take place.)


## Copyright

Copyright and related rights waived via CC0.
