### PR TITLE
 fix typo Update lip-4.md

### DIFF
--- a/LIPs/lip-4.md
+++ b/LIPs/lip-4.md
@@ -57,7 +57,7 @@ The user can enable the Profile Guardian back by executing `enableTokenGuardian`
 
 ### 3. Profile Guardian does not apply to non-EOA addresses
 
-Non-EOA addresses are not affected by this safety layer in order to avoid issues with smart contracts (e.g. NFT protocols or smart wallets) that expect the default plain ERC-721 behaviour. Non-EOA adresses have a higher safety assumption as significant amount of the non-EOAs are multisigs, DAOs or protocols that have a higher threshold of observation from the users and are assumed to remain less affected.
+Non-EOA addresses are not affected by this safety layer in order to avoid issues with smart contracts (e.g. NFT protocols or smart wallets) that expect the default plain ERC-721 behaviour. Non-EOA addresses have a higher safety assumption as significant amount of the non-EOAs are multisigs, DAOs or protocols that have a higher threshold of observation from the users and are assumed to remain less affected.
 
 ### 4. Lens ecosystem support
 


### PR DESCRIPTION
## Pull Request Title
fix: typo "adresses" to "addresses" in lip-4.md

### Description
This pull request corrects a typographical error in the `lip-4.md` file:
- Replaced "adresses" with "addresses" for consistency and accuracy.

### Changes Made
- Fixed the typo in the "Non-EOA addresses" section.


